### PR TITLE
Run insert hello world exec in the aptly homedir

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -213,6 +213,7 @@ class aptly_profile(
           $insert_hello_script, '--repo', $repo_name,
         ]),
         user        => $aptly_user,
+        cwd         => $aptly_homedir,
         refreshonly => true,
         subscribe   => Exec["aptly_repo_create-${repo_name}"],
         require     => File[$insert_hello_script],


### PR DESCRIPTION
Otherwise, we might get permission denied errors
when trying to use the reset workingdir function inside
the script (when trying to go back to /root)